### PR TITLE
sort zoom levels numerically

### DIFF
--- a/tile2sqlite.sh
+++ b/tile2sqlite.sh
@@ -21,7 +21,7 @@ dm=$(echo "$dt3/60" | bc)
 ds=$(echo "$dt3-60*$dm" | bc)
 }
 #list 1st level dirs as zoom
-my_dirs+=( $(ls -d -v   $1/*/ | sed "s/$1\///g" | sed 's/\///g') )
+my_dirs+=( $(ls -d -v   $1/*/ | sed "s/$1\///g" | sed 's/\///g' | sort -n) )
 last_element=${#my_dirs[*]}-1
 
 #create & initialize tables in sqlite


### PR DESCRIPTION
The default sorting is alphabetically instead of numerically. Because of that `last_element` gets assigned a wrong value.

Example of alphabetically sorted zoom levels:

```
0
1
10
11
12
13
14
15
16
17
18
2
3
4
5
6
7
8
9
```